### PR TITLE
Fix wrong function input order in setLobbyStartToStart

### DIFF
--- a/app/services/games/lobby/start/startLobbyHandler.ts
+++ b/app/services/games/lobby/start/startLobbyHandler.ts
@@ -20,7 +20,7 @@ async function startLobbyHandler(
   try {
     validConnectionCheck(userId, lobbyId);
     canLobbyBeStartedCheck(lobbyId);
-    setLobbyStateToStart(lobbyId, userId);
+    setLobbyStateToStart(userId, lobbyId);
     const newGameManager = gameManagerCreate(lobbyId);
     GameManagers.set(newGameManager.getId, newGameManager);
     addGameToDatabase(


### PR DESCRIPTION
Fix wrong function input order in setLobbyStartToStart in Start Lobby API (bug fixed).
Thought it was a bigger bug, but it turned out to be just a simple mistake.