### PR TITLE
219 tournament add ai to tournament

### DIFF
--- a/app/interfaces/games/tournament/TournamentMember.ts
+++ b/app/interfaces/games/tournament/TournamentMember.ts
@@ -10,7 +10,7 @@ type TournamentMemberStatus =
 
 export interface TournamentMember {
   id: string;
-  //  isAI: boolean;
+  isAI: boolean;
   status: TournamentMemberStatus;
   webSocket?: WebSocket;
 }

--- a/app/routes/games/tournament/add-ai-opponent/addAiOpponentToTournament.ts
+++ b/app/routes/games/tournament/add-ai-opponent/addAiOpponentToTournament.ts
@@ -1,0 +1,14 @@
+import type { FastifyPluginAsync } from "fastify";
+import addAIOpponentHandler from "../../../../services/games/tournament/addAiOpponent/addAiOpponentHandler";
+import addAiToTournamentSchema from "../../../../schemas/games/lobby/joinLobbySchema";
+
+const addAIOpponentToTournament: FastifyPluginAsync = async (
+  fastify,
+): Promise<void> => {
+  fastify.post("/:lobbyId", {
+    handler: addAIOpponentHandler,
+    schema: addAiToTournamentSchema,
+  });
+};
+
+export default addAIOpponentToTournament;

--- a/app/services/games/lobby/start/addGameToDatabase.ts
+++ b/app/services/games/lobby/start/addGameToDatabase.ts
@@ -7,9 +7,13 @@ const addGameToDatabase = async (
   db: Database,
   gameSettings: GameSettings,
 ) => {
-  await addMatchToDatabase(gameManager, db, gameSettings);
-  await addUserMatchesToDB(gameManager, db);
-  await addAIToDatabase(gameManager, db);
+  try {
+    await addMatchToDatabase(gameManager, db, gameSettings);
+    await addUserMatchesToDB(gameManager, db);
+    await addAIToDatabase(gameManager, db);
+  } catch (error) {
+    console.error("[addGameToDatabase] Error adding game to DB:", error);
+  }
 };
 
 const addUserMatchesToDB = async (gameManager: GameManager, db: Database) => {

--- a/app/services/games/matchMaking/createMatch.ts
+++ b/app/services/games/matchMaking/createMatch.ts
@@ -43,11 +43,7 @@ export const createMatch = async (
 
   gameManagers.set(gameManager.getId, gameManager);
 
-  try {
-    await addGameToDatabase(gameManager, db, gameModeSettings);
-  } catch (error) {
-    console.error("[createMatch] Error adding game to DB:", error);
-  }
+  await addGameToDatabase(gameManager, db, gameModeSettings);
 
   return gameManager.getId;
 };

--- a/app/services/games/matchMaking/createMatch.ts
+++ b/app/services/games/matchMaking/createMatch.ts
@@ -16,6 +16,7 @@ export const createMatch = async (
   gameMode: GameModeType,
   db: Database,
   gameOrigin?: GameOrigin,
+  aiOpponentIds?: string[],
 ): Promise<string> => {
   const gameModeSettings = GAMEMODE_REGISTRY[
     gameMode as keyof typeof GAMEMODE_REGISTRY
@@ -36,10 +37,17 @@ export const createMatch = async (
   playerIds.forEach((playerId) => {
     gameManager.addPlayer(playerId);
   });
+  aiOpponentIds?.forEach((aiOpponentId) => {
+    gameManager.addAiOpponent(aiOpponentId);
+  });
 
   gameManagers.set(gameManager.getId, gameManager);
 
-  await addGameToDatabase(gameManager, db, gameModeSettings);
+  try {
+    await addGameToDatabase(gameManager, db, gameModeSettings);
+  } catch (error) {
+    console.error("[createMatch] Error adding game to DB:", error);
+  }
 
   return gameManager.getId;
 };

--- a/app/services/games/tournament/TournamentManager.ts
+++ b/app/services/games/tournament/TournamentManager.ts
@@ -94,7 +94,7 @@ class TournamentManager {
     if (this.tournamentMembers.size >= this.tournamentSize) {
       throw new Error("[addAiOpponent] Tournament is already full");
     }
-    if (this.tournamentMembers.size >= aiOpponents.length)
+    if (this.getNumberOfAiOpponents() >= aiOpponents.length)
       throw new Error("[addAiOpponent] No more AI opponents available");
   }
 

--- a/app/services/games/tournament/addAiOpponent/addAiOpponentHandler.ts
+++ b/app/services/games/tournament/addAiOpponent/addAiOpponentHandler.ts
@@ -13,7 +13,7 @@ async function addAIOpponentHandler(
     const tournament = tournaments.get(tournamentId);
 
     tournament?.addAiOpponent(memberId);
-    return reply.send({ message: "AI Opponent has been added" });
+    return reply.code(200).send({ message: "AI Opponent has been added" });
   } catch (error) {
     if (error instanceof Error) return reply.badRequest(error.message);
   }

--- a/app/services/games/tournament/addAiOpponent/addAiOpponentHandler.ts
+++ b/app/services/games/tournament/addAiOpponent/addAiOpponentHandler.ts
@@ -1,0 +1,22 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import validTournamentConnectionCheck from "../tournamentValidation/validTournamentConnectionCheck";
+import { tournaments } from "../new/newTournamentHandler";
+
+async function addAIOpponentHandler(
+  request: FastifyRequest<{ Params: { lobbyId: string } }>, // eg tournamentId
+  reply: FastifyReply,
+): Promise<void> {
+  try {
+    const memberId = request.userId;
+    const tournamentId = request.params.lobbyId;
+    validTournamentConnectionCheck(memberId, tournamentId);
+    const tournament = tournaments.get(tournamentId);
+
+    tournament?.addAiOpponent(memberId);
+    return reply.send({ message: "AI Opponent has been added" });
+  } catch (error) {
+    if (error instanceof Error) return reply.badRequest(error.message);
+  }
+}
+
+export default addAIOpponentHandler;

--- a/app/services/games/tournament/websocket/createTournament.ts
+++ b/app/services/games/tournament/websocket/createTournament.ts
@@ -47,9 +47,9 @@ const addTournamentToDB = async (
   try {
     db.run(
       `
-           INSERT INTO tournaments
-           (id, status, mode)
-           VALUES (?, ?, ?)`,
+        INSERT INTO tournaments
+        (id, status, mode)
+        VALUES (?, ?, ?)`,
       [tournamentId, tournamentStatus, gameMode],
     );
   } catch (error) {


### PR DESCRIPTION
Add new endpoint: 

tournament/add-ai-opponent/:tournamentId

This this endpoint will add a new ai opponent to the tournament.  Just the Owner is allowed to add AIs.

One bug that will happen is if you play with more than one ai, the game where two ais play against each will not start. That but will be fixed in the future, issue is already opened. 

In a tournament an AI is treated the same as a usual member, just that in the tournamentMember the bool isAI is set to true. 