### PR TITLE
312 leaving lobbies broken

### DIFF
--- a/app/services/games/gameHandler/GameManager.ts
+++ b/app/services/games/gameHandler/GameManager.ts
@@ -20,6 +20,7 @@ import { FastifyInstance } from "fastify";
 import { fastifyInstance } from "../../../app";
 import { getLobby } from "../lobby/lobbyWebsocket/getLobby";
 import { removeMemberFromLobby } from "../lobby/leave/leaveLobbyHandler";
+import { isUserInAnyLobby } from "../lobby/lobbyVaidation/isUserInAnyLobby";
 
 class GameManager {
   private id: string = randomUUID();
@@ -224,7 +225,10 @@ class GameManager {
       this.disqualifyPlayer(playerId);
       player.leftGame = true;
     }
-    if (this.gameOrigin?.type === "lobby") {
+    if (
+      this.gameOrigin?.type === "lobby" &&
+      isUserInAnyLobby(playerId) !== null
+    ) {
       const lobby = getLobby(this.gameOrigin.lobby.getLobbyId);
       removeMemberFromLobby(lobby.getLobbyId, playerId);
     }

--- a/app/services/games/gameHandler/leaveGame/leaveGameHandler.ts
+++ b/app/services/games/gameHandler/leaveGame/leaveGameHandler.ts
@@ -16,7 +16,14 @@ async function leaveGameHandler(
 
     gameValidationCheck(userId, gameManager.getId());
 
-    gameManager.leaveGame(userId);
+    try {
+      gameManager.leaveGame(userId);
+    } catch (error) {
+      if (error instanceof Error) {
+        return reply.badRequest(error.message);
+      }
+    }
+
     return reply.redirect("/play");
   } catch (error) {
     if (error instanceof Error) return reply.badRequest(error.message);

--- a/app/services/games/lobby/Lobby.ts
+++ b/app/services/games/lobby/Lobby.ts
@@ -118,17 +118,16 @@ class Lobby {
   }
 
   public disconnectMember(memberId: string): void {
-    if (
-      this.lobbyMembers.get(memberId)?.userState === "inMatch" ||
-      this.lobbyMembers.get(memberId)?.socket === undefined
-    ) {
-      throw new Error(
-        "[disconnectMember] Member is not in the lobby WebSocket",
-      );
+    const member = this.lobbyMembers.get(memberId);
+    if (member === undefined) {
+      throw new Error("[disconnectMember] Member is not in the lobby");
     }
-    this.lobbyMembers.get(memberId)!.userState = "notInLobby";
-    this.lobbyMembers.get(memberId)!.socket!.close();
-    this.lobbyMembers.get(memberId)!.socket = undefined;
+
+    member.userState = "notInLobby";
+    if (member.socket !== undefined) {
+      member.socket.close();
+      member.socket = undefined;
+    }
   }
 
   public addSocketToMember(memberId: string, socket: WebSocket): void {

--- a/app/services/games/lobby/lobbyWebsocket/getLobby.ts
+++ b/app/services/games/lobby/lobbyWebsocket/getLobby.ts
@@ -8,7 +8,7 @@ function getLobby(lobbyId: string): Lobby {
   if (PrivateLobbies.has(lobbyId)) {
     return PrivateLobbies.get(lobbyId)!;
   }
-  throw new Error("getLobby Lobby does not exist");
+  throw new Error("[getLobby] Lobby does not exist");
 }
 
 function lobbyExists(lobbyId: string): boolean {


### PR DESCRIPTION
Previously, users could only leave the lobby when they were actively connected to the socket. Now, they can also leave when they are not connected.

Additionally, when the owner left the game while still in a lobby, the lobby was closed. Then, when other users left, the gameManager tried to remove them from the lobby again, even though it had already been removed. The leave function now checks not only the gameOrigin, but also whether the user is still part of an existing lobby.

Please test all your cases again. I tested with Classic Pong as well as multiplayer lobbies.