### PR TITLE
315 tournament error in bestofx matchwinner

### DIFF
--- a/app/gameRegistry.json
+++ b/app/gameRegistry.json
@@ -32,8 +32,7 @@
             "bumper": 1,
             "portals": 1,
             "speedGate": 1,
-            "protectedPowerUp": 2,
-            "bumperShield": 1
+            "protectedPowerUp": 2
           }
         }
       },
@@ -67,8 +66,7 @@
             "bumper": 1,
             "portals": 1,
             "speedGate": 1,
-            "protectedPowerUp": 3,
-            "bumperShield": 1
+            "protectedPowerUp": 2
           }
         }
       }
@@ -140,7 +138,7 @@
     "powerUps": {
       "speedBoost": {
         "className": "SpeedBoost",
-        "spawnWeight": 2.0,
+        "spawnWeight": 1.0,
         "selfActivation": false,
         "durationS": 5,
         "rampUpStrengthPercent": 4.5,
@@ -149,7 +147,7 @@
 
       "blinkingBall": {
         "className": "BlinkingBall",
-        "spawnWeight": 1.5,
+        "spawnWeight": 1.0,
         "selfActivation": false,
         "durationS": 6,
         "blinkIntervalS": 0.5,
@@ -158,7 +156,7 @@
 
       "multiBall": {
         "className": "MultiBall",
-        "spawnWeight": 1.5,
+        "spawnWeight": 1.0,
         "selfActivation": false,
         "durationS": 6,
         "ballCount": 8,
@@ -194,7 +192,7 @@
 
       "portals": {
         "className": "Portals",
-        "spawnWeight": 3.0,
+        "spawnWeight": 1.0,
         "selfActivation": false,
         "durationS": 60,
         "portalWallWidthHeightPercent": 40,
@@ -209,7 +207,7 @@
 
       "speedGate": {
         "className": "SpeedGate",
-        "spawnWeight": 3.0,
+        "spawnWeight": 1.0,
         "selfActivation": false,
         "durationS": 60,
         "initialBallSizeSmallPortalWidthPercent": 900,
@@ -224,7 +222,7 @@
 
       "protectedPowerUp": {
         "className": "ProtectedPowerUp",
-        "spawnWeight": 3.0,
+        "spawnWeight": 1.0,
         "selfActivation": false,
         "powerUpName": "bumperShield",
         "powerUpRadiusWidthPercent": 6,
@@ -236,7 +234,7 @@
 
       "bumperShield": {
         "className": "BumperShield",
-        "spawnWeight": 1.0,
+        "spawnWeight": 0.0,
         "selfActivation": false,
         "wallsHitThresold": 3,
         "wallTotalWidthArenaWidthPercent": 21,

--- a/app/services/strategy/tournamentMatchWinner/bestOfX.ts
+++ b/app/services/strategy/tournamentMatchWinner/bestOfX.ts
@@ -50,6 +50,7 @@ export class BestOfX implements ITournamentMatchWinner {
 
     // Record positions for each player
     Object.entries(gameResult).forEach(([playerID, position]) => {
+      if (!match.results[playerID]) return;
       match.results[playerID].push(position);
     });
 


### PR DESCRIPTION
Seems to be happening because when initializing the match w/ someone that left but the game still has the ID.
It's now protected & since no one can leave it shouldn't happen anymore.