### PR TITLE
Added gameResults[playerID] protection

### DIFF
--- a/app/services/games/tournament/tournamentVisualizer.ts
+++ b/app/services/games/tournament/tournamentVisualizer.ts
@@ -100,7 +100,7 @@ export async function hydratePlayerScores(
 
         for (const playerID of playerIDs) {
           const player = match.players.find((player) => player.id === playerID);
-          if (!player) continue;
+          if (!player || !gameResults[playerID]) continue;
           player.score.push(...gameResults[playerID]);
         }
       }


### PR DESCRIPTION
Again happens because a playerID was there for the creation of the game but it had no results.
It's now protected and since no one is leaving the tournament anymore it shouldn't happen anymore.