### PR TITLE
Add Nginx reverse proxy for Grafana & Prometheus

### DIFF
--- a/compose-prod/docker-compose.yml
+++ b/compose-prod/docker-compose.yml
@@ -21,12 +21,16 @@ services:
         container_name: nginx
         volumes:
             - ./nginx.conf:/etc/nginx/conf.d/default.conf
+            - ./grafana.conf:/etc/nginx/conf.d/grafana.conf
+            - ./prometheus.conf:/etc/nginx/conf.d/prometheus.conf
             - nginx-ssl:/etc/ssl
         depends_on:
             - app
         ports:
-            - 80:80
-            - 443:443
+            - "80:80"
+            - "443:443"
+            - "4000:4000"
+            - "9090:9090"
         command: |
             bash -c "if [ ! -f /etc/ssl/nginx.key ] || [ ! -f /etc/ssl/nginx.crt ]; then \
                 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/nginx.key -out /etc/ssl/nginx.crt -subj '/CN=localhost'; \
@@ -38,8 +42,6 @@ services:
         volumes:
             - ../monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
             - prometheus-data:/prometheus
-        ports:
-            - "9090:9090"
         restart: unless-stopped
 
     grafana:
@@ -48,8 +50,6 @@ services:
         volumes:
             - grafana-data:/var/lib/grafana
             - ../monitoring/grafana/provisioning:/etc/grafana/provisioning
-        ports:
-            - "4000:3000"
         restart: unless-stopped
         environment:
             - GF_SECURITY_ADMIN_USER=admin

--- a/compose-prod/grafana.conf
+++ b/compose-prod/grafana.conf
@@ -1,0 +1,50 @@
+# This is required to proxy Grafana Live WebSocket connections.
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+upstream grafana {
+  server grafana:3000;
+}
+
+server {
+  listen 4000 ssl;
+  root /usr/share/nginx/html;
+  index index.html index.htm;
+
+  # Your SSL/TLS certificate (chain) and secret key in the PEM format
+  ssl_certificate /etc/ssl/nginx.crt;
+  ssl_certificate_key /etc/ssl/nginx.key;
+
+  # A generic best practice baseline for based
+  # on https://ssl-config.mozilla.org/
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:FastifyApp:10m;
+  ssl_session_tickets off;
+
+  # This tells NGINX to only accept TLS 1.3, which should be fine
+  # with most modern browsers including IE 11 with certain updates.
+  # If you want to support older browsers you might need to add
+  # additional fallback protocols.
+  ssl_protocols TLSv1.3;
+  ssl_prefer_server_ciphers off;
+
+  # This adds a header that tells browsers to only ever use HTTPS
+  # with this server.
+  add_header Strict-Transport-Security "max-age=63072000" always;
+
+  location / {
+    proxy_set_header Host $host;
+    proxy_pass http://grafana;
+  }
+
+  # Proxy Grafana Live WebSocket connections.
+  location /api/live/ {
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Host $host;
+    proxy_pass http://grafana;
+  }
+}

--- a/compose-prod/nginx.conf
+++ b/compose-prod/nginx.conf
@@ -40,7 +40,7 @@ server {
   # server_name example.tld;
 
   # Enable HTTP/2 support
-  http2 on;
+  # http2 on;
 
   # Your SSL/TLS certificate (chain) and secret key in the PEM format
   ssl_certificate /etc/ssl/nginx.crt;

--- a/compose-prod/nginx.conf
+++ b/compose-prod/nginx.conf
@@ -40,7 +40,7 @@ server {
   # server_name example.tld;
 
   # Enable HTTP/2 support
-  # http2 on;
+  http2 on;
 
   # Your SSL/TLS certificate (chain) and secret key in the PEM format
   ssl_certificate /etc/ssl/nginx.crt;

--- a/compose-prod/prometheus.conf
+++ b/compose-prod/prometheus.conf
@@ -1,0 +1,28 @@
+server {
+    listen 9090 ssl;
+
+    # Your SSL/TLS certificate (chain) and secret key in the PEM format
+    ssl_certificate /etc/ssl/nginx.crt;
+    ssl_certificate_key /etc/ssl/nginx.key;
+
+    # A generic best practice baseline for based
+    # on https://ssl-config.mozilla.org/
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:FastifyApp:10m;
+    ssl_session_tickets off;
+
+    # This tells NGINX to only accept TLS 1.3, which should be fine
+    # with most modern browsers including IE 11 with certain updates.
+    # If you want to support older browsers you might need to add
+    # additional fallback protocols.
+    ssl_protocols TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
+    # This adds a header that tells browsers to only ever use HTTPS
+    # with this server.
+    add_header Strict-Transport-Security "max-age=63072000" always;
+
+    location / {
+        proxy_pass http://prometheus:9090/;
+    }
+}


### PR DESCRIPTION
Nginx now handles SSL termination for Grafana (port 4000) and Prometheus (port 9090). Direct port exposure for these services has been removed from their respective containers.