### PR TITLE
374 fix tournament Issues

### DIFF
--- a/app/services/games/tournament/TournamentManager.ts
+++ b/app/services/games/tournament/TournamentManager.ts
@@ -182,7 +182,6 @@ class TournamentManager {
       return false;
     if (this.tournament?.getStatus() === TournamentStatus.FINISHED)
       return false;
-    if (this.allMembersAreConnected() === false) return false;
     return true;
   }
 

--- a/app/services/games/tournament/TournamentManager.ts
+++ b/app/services/games/tournament/TournamentManager.ts
@@ -133,6 +133,7 @@ class TournamentManager {
       );
       return;
     }
+
     const member = this.tournamentMembers.get(memberId);
     member?.webSocket?.close();
     this.tournamentMembers.delete(memberId);
@@ -365,16 +366,16 @@ class TournamentManager {
   }
 
   public canTournamentBeLeavedCheck(memberId: string): void {
-    // that function throws
     if (this.tournamentMembers.has(memberId) === false) {
       throw new Error(
         `[canTournamentBeLeavedCheck] Member: ${memberId} does not exist`,
       );
     } else if (this.tournament?.getStatus() === TournamentStatus.CREATED) {
-      throw new Error(
-        `[canTournamentBeLeavedCheck] Tournament is already finished`,
-      );
-    } else if (this.isPlayerEliminated(memberId) === false) {
+      throw new Error(`[canTournamentBeLeavedCheck] started already`);
+    } else if (
+      this.tournament !== undefined &&
+      this.isPlayerEliminated(memberId) === false
+    ) {
       throw new Error(
         `[canTournamentBeLeavedCheck] Member has to play games in the tournament still`,
       );

--- a/app/services/games/tournament/TournamentManager.ts
+++ b/app/services/games/tournament/TournamentManager.ts
@@ -136,12 +136,8 @@ class TournamentManager {
     const member = this.tournamentMembers.get(memberId);
     member?.webSocket?.close();
     this.tournamentMembers.delete(memberId);
-    if (
-      memberId === this.ownerId &&
-      this.tournament?.getStatus() === TournamentStatus.CREATED
-    ) {
-      this.changeOwner();
-    }
+
+    if (memberId === this.ownerId) this.changeOwner();
     this.sendMessageToAll({ type: "update" });
   }
 

--- a/app/services/games/tournament/join/joinTournamentHandler.ts
+++ b/app/services/games/tournament/join/joinTournamentHandler.ts
@@ -12,7 +12,7 @@ async function joinTournamentHandler(
     const memberId = request.userId;
     const tournamentId = request.params.lobbyId;
     const tournament = tournaments.get(tournamentId);
-    if (!tournament) return reply.notFound("Tournament not found");
+    if (!tournament) return reply.redirect("/play");
 
     canMemberJoinTournamentCheck(memberId, tournamentId);
     tournament.addMember(memberId);


### PR DESCRIPTION
1. Error: Had to reload the page to start the tournament.
   Fix: Removed the check for WebSocket connection, as players are not connected 
   to the tournament WebSocket when they are in the lobby.

2. Error: Attempting to join a closed lobby redirected the user to an error page.
   Fix: Now redirects to /play instead of showing an error page.

3. Error: When the tournament owner left, ownership was not transferred.
   Fix: Ownership is now always transferred when the owner leaves, not just after tournament creation.

4. Error: Players couldn't leave the tournament before it was started.
   Fix: Added a check to ensure the "is eliminated" flag is only used when a tournament actually exists.
